### PR TITLE
Remove carriage return character from header row

### DIFF
--- a/import.py
+++ b/import.py
@@ -167,7 +167,7 @@ def to_file(bcpdata, csvfilename="", col_headers=None):
             if(col_headers):
                 for c in col_headers:
                     c = c
-                writer = csv.writer(csvfile)
+                writer = csv.writer(csvfile, lineterminator='\n')
                 writer.writerow(col_headers)
             csvfile.write(bcpdata)
 


### PR DESCRIPTION
The CSV writer adds an extra carriage return (^M) character at the end of the header row. This interferes when loading the produced CSV files with Ruby. Setting `lineterminator='\n'` can ensure that the extra character isn't produced.

Tested with Python 3.5 on Linux.

[0] - http://stackoverflow.com/a/17725590