### PR TITLE
Remove nul chars, escape quotes as per RFC4180, remove final empty line

### DIFF
--- a/bcp.py
+++ b/bcp.py
@@ -6,11 +6,14 @@ def convert(bcpdata, lineterminator='*@@*', delimiter='@**@', quote='"', newdeli
     """
     returns data from a string of BCP data. Default is to present as CSV data.
     """
-    bcpdata = bcpdata.replace(escapechar, escapechar + escapechar)
-    bcpdata = bcpdata.replace(quote, escapechar + quote)
+    #bcpdata = bcpdata.replace(escapechar, escapechar + escapechar)
+    bcpdata = bcpdata.replace(quote, quote + quote)
+    bcpdata = bcpdata.replace("\0", "")
     bcpdata = bcpdata.replace(delimiter, quote + newdelimiter + quote)
     bcpdata = bcpdata.replace(lineterminator, quote + newline + quote)
     bcpdata = quote + bcpdata + quote
+    if bcpdata[-3:] == '\n""':
+        bcpdata = bcpdata[:-3]
     return bcpdata
 
 def stream(file, lineterminator='*@@*', delimiter='@**@', encoding='utf-8'):


### PR DESCRIPTION
Similar to [PR9](https://github.com/ncvo/charity-commission-extract/pull/9), this tweaks `bcp.py` to remove NUL characters, properly escape quote characters  ( " ) and thus avoid commas within fields being interpreted as delimiters.

Differs from PR9 in that it doesn't convert double-quote characters into single-quote characters; instead it keeps them as double-quotes correctly escaped as per [RFC 4190](https://tools.ietf.org/html/rfc4180).